### PR TITLE
Fixed P2WSH and P2WPKH calculations and tests

### DIFF
--- a/bitcoinaddress/address.py
+++ b/bitcoinaddress/address.py
@@ -45,7 +45,8 @@ class Address:
             self.pubaddr3 = self.instance._generate_publicaddress3(Address.MainNet.SEGWIT_PREFIX)
 
         def generate_publicaddress_bc1_P2WPKH(self):
-            self.pubaddrbc1_P2WPKH = self.instance._generate_publicaddress_bech32_P2WPKH(Address.MainNet.BECH32_PREFIX)
+            self.pubaddrbc1_P2WPKH = self.instance._generate_publicaddress_bech32_P2WPKH(Address.MainNet.BECH32_PREFIX, 
+                                                                                         Address.MainNet.PREFIX_B)
 
         def generate_publicaddress_bc1_P2WSH(self):
             self.pubaddrbc1_P2WSH = self.instance._generate_publicaddress_bech32_P2WSH(Address.MainNet.BECH32_PREFIX)
@@ -70,7 +71,8 @@ class Address:
             self.pubaddr3 = self.instance._generate_publicaddress3(Address.TestNet.SEGWIT_PREFIX)
 
         def generate_publicaddress_tb1_P2WPKH(self):
-            self.pubaddrtb1_P2WPKH = self.instance._generate_publicaddress_bech32_P2WPKH(Address.TestNet.BECH32_PREFIX)
+            self.pubaddrtb1_P2WPKH = self.instance._generate_publicaddress_bech32_P2WPKH(Address.TestNet.BECH32_PREFIX, 
+                                                                                         Address.TestNet.PREFIX_B)
 
         def generate_publicaddress_tb1_P2WSH(self):
             self.pubaddrtb1_P2WSH = self.instance._generate_publicaddress_bech32_P2WSH(Address.TestNet.BECH32_PREFIX)
@@ -122,14 +124,17 @@ class Address:
         c = checksum(m)
         return base58.b58encode(m + c).decode('utf-8')
 
-    def _generate_publicaddress_bech32_P2WPKH(self, bech32_prefix):
-        p = self._generate_compressed_pubkey()
+    def _generate_publicaddress_bech32_P2WPKH(self, bech32_prefix, prefix_b):
+        p = self._generate_uncompressed_pubkey(prefix_b)
         redeem_script_P2WPKH = hash160(p).digest()  # 20 bytes
         return str(segwit_addr.encode(bech32_prefix, Address.WITNESS_VERSION, redeem_script_P2WPKH))
 
     def _generate_publicaddress_bech32_P2WSH(self, bech32_prefix):
         p = self._generate_compressed_pubkey()
-        redeem_script_P2WSH = hashlib.sha256(p).digest()
+        pr1 = bytes.fromhex('21')
+        po1 = bytes.fromhex('ac')
+        p_red = pr1 + p + po1
+        redeem_script_P2WSH = hashlib.sha256(p_red).digest()
         return str(segwit_addr.encode(bech32_prefix, Address.WITNESS_VERSION, redeem_script_P2WSH))
 
     def _generate_uncompressed_pubkey(self, prefix):

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -18,15 +18,15 @@ class TestAddress(unittest.TestCase):
         self.assertEqual(address.mainnet.pubaddr1c, "1D7XaU5PbsPxfZeYBcGGyMEqiVvPhtFMUF")
         self.assertEqual(address.mainnet.pubaddr3, "34QhdWUjZjv3HLyvNYgb4AR7ikAfcdzfCW")
         self.assertEqual(address.mainnet.pubaddrbc1_P2WSH,
-                         "bc1qup6umurcl7s6zw42gcxfzl346psazws74x72ty6gmlvkaxz6kv4sqsth99")
-        self.assertEqual(address.mainnet.pubaddrbc1_P2WPKH, "bc1qsnwc0y43fpljyl2ep0e2gtsqa55utcj4ntzwlf")
+                         "bc1q6gmqnd9x8q40gusftcxw84sjmdszcp3hv0ur3k7aufvjwzw5y77sl2kknp")
+        self.assertEqual(address.mainnet.pubaddrbc1_P2WPKH, "bc1qaj3zyc83azvukfr5kyltf3guyzca44lhzgq6la")
 
         self.assertEqual(address.testnet.pubaddr1, "n369zca37LR8Pzc2GBKh5CzitRxxhkHDhK")
         self.assertEqual(address.testnet.pubaddr1c, "msdUsXANQtqDSg89uBEeoGTAaVX6bWK3dW")
         self.assertEqual(address.testnet.pubaddr3, "2MuxuhFQmBCRPV8cU3gJTg7QNw6NqTuUm2A")
         self.assertEqual(address.testnet.pubaddrtb1_P2WSH,
-                         "tb1qup6umurcl7s6zw42gcxfzl346psazws74x72ty6gmlvkaxz6kv4shcacl2")
-        self.assertEqual(address.testnet.pubaddrtb1_P2WPKH, "tb1qsnwc0y43fpljyl2ep0e2gtsqa55utcj4edeay6")
+                         "tb1q6gmqnd9x8q40gusftcxw84sjmdszcp3hv0ur3k7aufvjwzw5y77sgzqefw")
+        self.assertEqual(address.testnet.pubaddrtb1_P2WPKH, "tb1qaj3zyc83azvukfr5kyltf3guyzca44lhgwmfyw")
 
     def testFromRandomSeed(self):
         # when


### PR DESCRIPTION
This should hopefully fix the calculations of bech32 P2WSH and P2WPKH (#13)

The fix for P2WSH comes from @s256s9 - to the best of my ability to confirm, it produces a valid result.

The fix for P2WPKH comes from my efforts to understand the generation process. The correctness can be verified, for instance, on https://privatekeys.pw/address/bitcoin/1NaChZV4JJysct8QYcMKFHnQ2SNFpnBund (uses the public key from `test_address.py`).